### PR TITLE
Allow setting the delay and test server using environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ RUN dos2unix capture.sh && \
     chmod +x cap*.sh && \
     chmod +x start.sh
     ENV delay 5
+    ENV server 0
 
  CMD ["./start.sh"]       

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN dos2unix capture.sh && \
     dos2unix start.sh && \ 
     chmod +x cap*.sh && \
     chmod +x start.sh
+    ENV delay 5
 
  CMD ["./start.sh"]       

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ docker build -t speedtest .
 
 To start, run:
 ```
-docker run --rm -it -p 8000:8000 speedtest
+docker run --rm -it -e delay=5 -p 8000:8000 speedtest
 ```
 
 Then browse to http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ docker build -t speedtest .
 
 To start, run:
 ```
-docker run --rm -it -e delay=5 -p 8000:8000 speedtest
+docker run --rm -it -e delay=5 -e server=0 -p 8000:8000 speedtest
 ```
 
 Then browse to http://localhost:8000

--- a/cap5min.sh
+++ b/cap5min.sh
@@ -8,7 +8,8 @@ re='^[0-9]+$'
 if [[ $delay =~ $re ]] ; then #If $delay is not a number (including when it isnt set)
   delay=5
 fi
-time=$(($delay * 60))# $delay is in minutes, $time is in seconds
+sec=60
+time=$((sec*delay))# $delay is in minutes, $time is in seconds
 
 while :
 do

--- a/cap5min.sh
+++ b/cap5min.sh
@@ -4,10 +4,16 @@ if [ ! -f results.csv ]; then
     echo "ts,datetime,ping,download,upload" > results.csv
 fi
 
+re='^[0-9]+$'
+if [[ $delay =~ $re ]] ; then #If $delay is not a number (including when it isnt set)
+  delay=5
+fi
+time=$(($delay * 60))# $delay is in minutes, $time is in seconds
+
 while :
 do
     echo "Running test...."
     ./capture.sh
-    echo "Waiting 5 minutes..."
-    sleep 300
+    echo "Waiting $delay minutes..."
+    sleep $time
 done

--- a/capture.sh
+++ b/capture.sh
@@ -4,7 +4,15 @@
 
 NOW=$(date +"%s,%Y-%m-%d %T")
 
-speedtest-cli --server 4135 --simple > /tmp/speedtest-results
+if [ $server -ne 0 ]; then #false if equal to 0 or not a number (does show an error if not a number or not set, non fatal)
+  echo "Server has been set to $server"
+  srv="--server $server"
+else
+  echo "Automatically selecting server"
+  srv=""
+fi
+
+speedtest-cli $srv --simple > /tmp/speedtest-results
 # TODO check for errors
 
 


### PR DESCRIPTION
**DONT MERGE THIS PULL REQUEST YET**
Just trying to sort out a few problems with it

# DELAY
I wanted to be able to change to 15 minute delays, so i did this

if using docker run, add `-e delay=15` to the docker run command.

if using docker compose, add 
```
    environment:
      - delay=15
```

# Test Server
originally the server was hard coded to be 4135 (in auckland) and this was giving me bad results.
I have changed this so it is set via environment variables.

if using docker run, add `-e server=1234` to the docker run command.

if using docker compose, add 
```
    environment:
      - server=1234
```
if you dont provide a server (or set it to 0 / not a number), the server will be automatically chosen based on latency